### PR TITLE
ERR! not a package kinvey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .project
 .settings
+
+# JetBrains IDEs
+.idea

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "main"        : "./kinvey.js",
   "repository"  : {
     "type" : "git",
-    "url"  : "git@github.com:Kinvey/kinvey-nodejs.git"
+    "url"  : "https://github.com/Kinvey/kinvey-nodejs.git"
   },
   "dependencies": {
     "promiscuous": "~0.6"


### PR DESCRIPTION
Currently, when installing with npm, you get an error (below).  I believe this is due to the package.json repository url being incorrectly formatted.  This PR updates the package.json repo url to an accepted npm format.

Another alternative would be to use the format shown in the [docs for repository](https://docs.npmjs.com/files/package.json#repository) instead.

Please verify this is correct and update the npm package if you could.  Thanks much for your help!

``` terminal
› npm i kinvey -S        
npm WARN package.json express-livereload@0.0.24 No repository field.
npm ERR! not a package kinvey
npm ERR! addLocal Could not install kinvey
npm ERR! Darwin 13.4.0
npm ERR! argv "node" "/usr/local/bin/npm" "i" "kinvey" "-S"
npm ERR! node v0.10.32
npm ERR! npm  v2.1.2
npm ERR! path /var/folders/k2/ybprgn_53pqgrx4rr7f3hyrc0000gp/T/npm-10639-72728594/unpack-0933f740bbfa/package.json
npm ERR! code ENOENT
npm ERR! errno 34

npm ERR! ENOENT, open '/var/folders/k2/ybprgn_53pqgrx4rr7f3hyrc0000gp/T/npm-10639-72728594/unpack-0933f740bbfa/package.json'
npm ERR! 
npm ERR! If you need help, you may report this error at:
npm ERR!     <http://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     <path-to-project>/npm-debug.log
```
